### PR TITLE
uart: abstract debug logging to wrapper function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SRC = Musashi/m68kcpu.c Musashi/softfloat/softfloat.c Musashi/m68kops.c
-SRC +=  main.c uart.c csr.c ramrom.c mapper.c scsi.c mbus.c rtc.c
+SRC +=  main.c uart.c csr.c ramrom.c mapper.c scsi.c mbus.c rtc.c log.c
 
 DEPFLAGS = -MT $@ -MMD -MP
 CFLAGS=-ggdb -Og -Wall $(DEPFLAGS)

--- a/log.c
+++ b/log.c
@@ -1,0 +1,22 @@
+#include "log.h"
+#include <stdio.h>
+#include <stdarg.h>
+
+// Default log levels for log sources
+#define LOG_UART_DEFAULT_LEVEL LOG_ERR
+
+int log_channel_verbose_level[] = {
+	LOG_UART_DEFAULT_LEVEL
+};
+
+int log_printf(enum log_source source, int msg_level, const char *format, ...) {
+        va_list ap;
+        int printed = 0;
+
+        if (log_channel_verbose_level[source] >= msg_level) {
+                va_start(ap, format);
+                printed = vprintf(format, ap);
+                va_end(ap);
+        }
+        return printed;
+}

--- a/log.h
+++ b/log.h
@@ -1,0 +1,19 @@
+#ifndef LOG_H
+#define LOG_H
+
+// Log sources (should be numbered sequentially from 0)
+enum log_source {
+	LOG_SRC_UART = 0
+};
+
+
+// Emulator log levels (higher is more verbose)
+#define LOG_ERR        0
+#define LOG_WARNING    1
+#define LOG_NOTICE     2
+#define LOG_INFO       3
+#define LOG_DEBUG      4
+
+int log_printf(enum log_source channel, int msg_level, const char *format, ...);
+
+#endif


### PR DESCRIPTION
Change commented out debug printf()s to `uart_debug_log`, enabled by `do_uart_debug` being non-zero.