### PR TITLE
csr: use log functions for debug logging

### DIFF
--- a/log.c
+++ b/log.c
@@ -4,9 +4,11 @@
 
 // Default log levels for log sources
 #define LOG_UART_DEFAULT_LEVEL LOG_ERR
+#define LOG_CSR_DEFAULT_LEVEL  LOG_ERR
 
 int log_channel_verbose_level[] = {
-	LOG_UART_DEFAULT_LEVEL
+	LOG_UART_DEFAULT_LEVEL,
+	LOG_CSR_DEFAULT_LEVEL
 };
 
 int log_printf(enum log_source source, int msg_level, const char *format, ...) {

--- a/log.h
+++ b/log.h
@@ -3,7 +3,8 @@
 
 // Log sources (should be numbered sequentially from 0)
 enum log_source {
-	LOG_SRC_UART = 0
+	LOG_SRC_UART = 0,
+	LOG_SRC_CSR  = 1
 };
 
 
@@ -14,6 +15,6 @@ enum log_source {
 #define LOG_INFO       3
 #define LOG_DEBUG      4
 
-int log_printf(enum log_source channel, int msg_level, const char *format, ...);
+int log_printf(enum log_source source, int msg_level, const char *format, ...);
 
 #endif

--- a/uart.c
+++ b/uart.c
@@ -7,9 +7,9 @@
 #include "log.h"
 
 // Debug logging
-#define UART_LOG(msg_level, format, args...) \
-	log_printf(LOG_SRC_UART, msg_level, format, args)
-#define UART_LOG_DEBUG(format, args...) UART_LOG(LOG_DEBUG, format, args)
+#define UART_LOG(msg_level, format_and_args...) \
+	log_printf(LOG_SRC_UART, msg_level, format_and_args)
+#define UART_LOG_DEBUG(format_and_args...) UART_LOG(LOG_DEBUG, format_and_args)
 
 //The UARTs are Mostek MK68564 chips.
 


### PR DESCRIPTION
Also standardise UART_LOG_* wrappers to same macro vararg handling.