### PR TITLE
Persistent RTC RAM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ emu
 *.d
 trace.txt
 plexus-sanitized.img
+rtcram.bin

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ emu
 *.o
 *.d
 trace.txt
+plexus-sanitized.img

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SRC = Musashi/m68kcpu.c Musashi/softfloat/softfloat.c Musashi/m68kops.c
 SRC += main.c uart.c csr.c ramrom.c mapper.c scsi.c mbus.c rtc.c log.c 
-SRC += emu.c scsi_dev_hd.c
+SRC += emu.c scsi_dev_hd.c rtcram.c
 
 DEPFLAGS = -MT $@ -MMD -MP
 CFLAGS=-ggdb -Og -Wall $(DEPFLAGS)

--- a/emu.c
+++ b/emu.c
@@ -14,6 +14,7 @@
 #include "scsi_dev_hd.h"
 #include "mbus.h"
 #include "rtc.h"
+#include "rtcram.h"
 #include "log.h"
 #include "emu.h"
 #include "int.h"
@@ -498,6 +499,20 @@ rtc_t *setup_rtc(const char *name) {
 	return r;
 }
 
+// RTC RAM is physically part of the RTC, but implemented in a different
+// virtual device for simplicity; it is like standard RAM, but persistent
+// over separate emulator runs.
+//
+void setup_rtcram(const char *name) {
+	mem_range_t *m=find_range_by_name(name);
+	m->obj=rtcram_new();
+	m->write8=rtcram_write8;
+	m->write16=rtcram_write16;
+	m->read8=rtcram_read8;
+	m->read16=rtcram_read16;
+	EMU_LOG_INFO("Set up 0x%X bytes of persistent RAM in section '%s'.\n", m->size, m->name);
+}
+
 csr_t *setup_csr(const char *name, const char *mmio_name, const char *scsi_name) {
 	mem_range_t *m=find_range_by_name(name);
 	mem_range_t *mm=find_range_by_name(mmio_name);
@@ -717,7 +732,7 @@ void emu_start(emu_cfg_t *cfg) {
 	tracefile=fopen("trace.txt","w");
 	setup_ram("RAM");
 	setup_ram("SRAM");
-	setup_ram("RTC_RAM");
+	setup_rtcram("RTC_RAM");
 	setup_rom("U15", cfg->u15_rom); //used to be U17
 	setup_rom("U17", cfg->u17_rom); //used to be U19
 	uart_t *uart[4];

--- a/emu.c
+++ b/emu.c
@@ -503,9 +503,9 @@ rtc_t *setup_rtc(const char *name) {
 // virtual device for simplicity; it is like standard RAM, but persistent
 // over separate emulator runs.
 //
-void setup_rtcram(const char *name) {
+void setup_rtcram(const char *name, const char *filename) {
 	mem_range_t *m=find_range_by_name(name);
-	m->obj=rtcram_new();
+	m->obj=rtcram_new(filename);
 	m->write8=rtcram_write8;
 	m->write16=rtcram_write16;
 	m->read8=rtcram_read8;
@@ -732,7 +732,7 @@ void emu_start(emu_cfg_t *cfg) {
 	tracefile=fopen("trace.txt","w");
 	setup_ram("RAM");
 	setup_ram("SRAM");
-	setup_rtcram("RTC_RAM");
+	setup_rtcram("RTC_RAM", cfg->rtcram);
 	setup_rom("U15", cfg->u15_rom); //used to be U17
 	setup_rom("U17", cfg->u17_rom); //used to be U19
 	uart_t *uart[4];

--- a/emu.c
+++ b/emu.c
@@ -508,8 +508,10 @@ void setup_rtcram(const char *name, const char *filename) {
 	m->obj=rtcram_new(filename);
 	m->write8=rtcram_write8;
 	m->write16=rtcram_write16;
+	m->write32=rtcram_write32;
 	m->read8=rtcram_read8;
 	m->read16=rtcram_read16;
+	m->read32=rtcram_read32;
 	EMU_LOG_INFO("Set up 0x%X bytes of persistent RAM in section '%s'.\n", m->size, m->name);
 }
 

--- a/emu.h
+++ b/emu.h
@@ -26,6 +26,7 @@ typedef struct {
 	const char *u15_rom;
 	const char *u17_rom;
 	const char *hd0img;
+	const char *rtcram;
 } emu_cfg_t;
 
 void emu_start(emu_cfg_t *cfg);

--- a/main.c
+++ b/main.c
@@ -62,7 +62,8 @@ int main(int argc, char **argv) {
 	emu_cfg_t cfg={
 		.u15_rom="../plexus-p20/ROMs/U15-MERGED.BIN",
 		.u17_rom="../plexus-p20/ROMs/U17-MERGED.BIN",
-		.hd0img="plexus-sanitized.img"
+		.hd0img="plexus-sanitized.img",
+		.rtcram="rtcram.bin"
 	};
 	int error=0;
 	for (int i=1; i<argc; i++) {

--- a/rtcram.c
+++ b/rtcram.c
@@ -1,0 +1,55 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+#include "emu.h"
+#include "log.h"
+#include "rtcram.h"
+
+// Debug logging (shared with the RTC clock portion)
+#define RTC_LOG(msg_level, format_and_args...) \
+        log_printf(LOG_SRC_RTC, msg_level, format_and_args)
+#define RTC_LOG_DEBUG(format_and_args...)  RTC_LOG(LOG_DEBUG,  format_and_args)
+#define RTC_LOG_INFO(format_and_args...)   RTC_LOG(LOG_INFO,   format_and_args)
+#define RTC_LOG_NOTICE(format_and_args...) RTC_LOG(LOG_NOTICE, format_and_args)
+
+struct rtcram_t {
+	uint8_t reg[64];
+};
+
+void rtcram_write8(void *obj, unsigned int a, unsigned int val) {
+	rtcram_t *r=(rtcram_t*)obj;
+
+	a=a/2; //rtc is on odd addresses
+	assert(a < sizeof(r->reg));
+
+	r->reg[a]=val;
+	RTC_LOG_DEBUG("RTC: wrote 0x%02x to RAM position 0x%02x\n", val, a);
+	RTC_LOG_INFO("RTC RAM write is not yet persisted to disk\n");
+}
+
+void rtcram_write16(void *obj, unsigned int a, unsigned int val) {
+	rtcram_write8(obj, a+1, val);
+}
+
+unsigned int rtcram_read8(void *obj, unsigned int a) {
+	rtcram_t *r=(rtcram_t*)obj;
+
+	a=a/2; //rtc is on odd addresses
+	assert(a < sizeof(r->reg));
+
+	int ret=r->reg[a];
+	return ret;
+}
+
+unsigned int rtcram_read16(void *obj, unsigned int a) {
+	return rtcram_read8(obj, a+1);
+}
+
+rtcram_t *rtcram_new() {
+	rtcram_t *ret=calloc(sizeof(rtcram_t), 1);
+	RTC_LOG_INFO("RTC RAM is not yet loaded from disk\n");
+	// TODO: load RTC RAM from disk if available
+	return ret;
+}

--- a/rtcram.c
+++ b/rtcram.c
@@ -10,23 +10,37 @@
 // Debug logging (shared with the RTC clock portion)
 #define RTC_LOG(msg_level, format_and_args...) \
         log_printf(LOG_SRC_RTC, msg_level, format_and_args)
-#define RTC_LOG_DEBUG(format_and_args...)  RTC_LOG(LOG_DEBUG,  format_and_args)
-#define RTC_LOG_INFO(format_and_args...)   RTC_LOG(LOG_INFO,   format_and_args)
-#define RTC_LOG_NOTICE(format_and_args...) RTC_LOG(LOG_NOTICE, format_and_args)
+#define RTC_LOG_DEBUG(format_and_args...)   RTC_LOG(LOG_DEBUG,   format_and_args)
+#define RTC_LOG_INFO(format_and_args...)    RTC_LOG(LOG_INFO,    format_and_args)
+#define RTC_LOG_NOTICE(format_and_args...)  RTC_LOG(LOG_NOTICE,  format_and_args)
+#define RTC_LOG_WARNING(format_and_args...) RTC_LOG(LOG_WARNING, format_and_args)
 
 struct rtcram_t {
 	uint8_t reg[64];
+	const char *filename;
 };
 
 void rtcram_write8(void *obj, unsigned int a, unsigned int val) {
 	rtcram_t *r=(rtcram_t*)obj;
+	FILE *rtcramfile = NULL;
+	size_t written = 0;
 
 	a=a/2; //rtc is on odd addresses
 	assert(a < sizeof(r->reg));
 
 	r->reg[a]=val;
 	RTC_LOG_DEBUG("RTC: wrote 0x%02x to RAM position 0x%02x\n", val, a);
-	RTC_LOG_INFO("RTC RAM write is not yet persisted to disk\n");
+
+	if ((rtcramfile = fopen(r->filename, "wb"))) {
+		written = fwrite(r->reg, sizeof(r->reg), 1, rtcramfile);
+		fclose(rtcramfile);
+	}
+
+	if (written == 1) {
+		RTC_LOG_DEBUG("RTC: RAM persisted to %s\n", r->filename);
+	} else {
+		RTC_LOG_WARNING("RTC: Failed to persist RTC RAM to %s\n", r->filename);
+	}
 }
 
 void rtcram_write16(void *obj, unsigned int a, unsigned int val) {
@@ -47,9 +61,24 @@ unsigned int rtcram_read16(void *obj, unsigned int a) {
 	return rtcram_read8(obj, a+1);
 }
 
-rtcram_t *rtcram_new() {
-	rtcram_t *ret=calloc(sizeof(rtcram_t), 1);
-	RTC_LOG_INFO("RTC RAM is not yet loaded from disk\n");
-	// TODO: load RTC RAM from disk if available
-	return ret;
+rtcram_t *rtcram_new(const char *filename) {
+	rtcram_t *r=calloc(sizeof(rtcram_t), 1);
+	r->filename=filename;
+
+	FILE *rtcramfile = NULL;
+	size_t rtcread   = 0;
+
+	if ((rtcramfile = fopen(r->filename, "rb"))) {
+		rtcread = fread(r->reg, sizeof(r->reg), 1, rtcramfile);
+		fclose(rtcramfile);
+	}
+
+	if (rtcread == 1) {
+		RTC_LOG_INFO("RTC: Loaded persistent RTC RAM from %s\n", r->filename);
+	} else {
+		RTC_LOG_NOTICE("RTC: Unable to load persistent RTC RAM from %s; using zeros\n",
+				r->filename);
+	}
+
+	return r;
 }

--- a/rtcram.c
+++ b/rtcram.c
@@ -47,6 +47,14 @@ void rtcram_write16(void *obj, unsigned int a, unsigned int val) {
 	rtcram_write8(obj, a+1, val);
 }
 
+// RTC RAM is at every second address, so write32 writes to
+// - lower 8 bits of top 16 bits
+// - lower 8 bits of bottom 16 bits
+void rtcram_write32(void *obj, unsigned int a, unsigned int val) {
+	rtcram_write8(obj, a+1, (val >> 16) & 0xFFFF); // lower 8 of upper 16
+	rtcram_write8(obj, a+3,  val        & 0xFFFF); // lower 8 of lower 16
+}
+
 unsigned int rtcram_read8(void *obj, unsigned int a) {
 	rtcram_t *r=(rtcram_t*)obj;
 
@@ -59,6 +67,14 @@ unsigned int rtcram_read8(void *obj, unsigned int a) {
 
 unsigned int rtcram_read16(void *obj, unsigned int a) {
 	return rtcram_read8(obj, a+1);
+}
+
+// RTC RAM is at every second address, so read32 reads from
+// - lower 8 bits of top 16 bits
+// - lower 8 bits of bottom 16 bits
+unsigned int rtcram_read32(void *obj, unsigned int a) {
+	return (((rtcram_read8(obj, a+1) & 0XFFFF) << 16) |
+	        ((rtcram_read8(obj, a+3) & 0xFFFF)));
 }
 
 rtcram_t *rtcram_new(const char *filename) {

--- a/rtcram.h
+++ b/rtcram.h
@@ -5,8 +5,10 @@ typedef struct rtcram_t rtcram_t;
 
 void rtcram_write8(void *obj, unsigned int a, unsigned int val);
 void rtcram_write16(void *obj, unsigned int a, unsigned int val);
+void rtcram_write32(void *obj, unsigned int a, unsigned int val);
 unsigned int rtcram_read8(void *obj, unsigned int a);
 unsigned int rtcram_read16(void *obj, unsigned int a);
+unsigned int rtcram_read32(void *obj, unsigned int a);
 rtcram_t *rtcram_new(const char *filename);
 
 #endif

--- a/rtcram.h
+++ b/rtcram.h
@@ -1,0 +1,12 @@
+#ifndef RTCRAM_H
+#define RTCRAM_H
+
+typedef struct rtcram_t rtcram_t;
+
+void rtcram_write8(void *obj, unsigned int a, unsigned int val);
+void rtcram_write16(void *obj, unsigned int a, unsigned int val);
+unsigned int rtcram_read8(void *obj, unsigned int a);
+unsigned int rtcram_read16(void *obj, unsigned int a);
+rtcram_t *rtcram_new();
+
+#endif

--- a/rtcram.h
+++ b/rtcram.h
@@ -7,6 +7,6 @@ void rtcram_write8(void *obj, unsigned int a, unsigned int val);
 void rtcram_write16(void *obj, unsigned int a, unsigned int val);
 unsigned int rtcram_read8(void *obj, unsigned int a);
 unsigned int rtcram_read16(void *obj, unsigned int a);
-rtcram_t *rtcram_new();
+rtcram_t *rtcram_new(const char *filename);
 
 #endif


### PR DESCRIPTION
Proof of concept conversion of the `RTC_RAM` section from plain RAM to persistent RAM.

On each write, RAM is persisted to `rtcram.bin` (default file), and on emulator start the RTC RAM is reloaded from that file if present.