### PR TITLE
Mapper avoid combine

### DIFF
--- a/mapper.c
+++ b/mapper.c
@@ -23,8 +23,47 @@ a page size of 4K.
 We have space for 8K physical pages; this means we could map
 to 32MiB of physical RAM.
 
-On write of 32-bit, w0 is msb and w1 lsb.
-Note the RWX bits *disable* that access when 1.
+On write of 32-bit, w0 is msb and w1 lsb.  This happens because our
+CPU emulator supports a 32-bit bus; the 68010 in the Plexus P/20 had
+only a 16-bit bus so there were two read/write cycles.
+
+Note the RWX bits *disable* that access when 1, ie they are "prohibited"
+bits not allow bits.
+
+
+Documentation from the Plexus P/20 specification:
+
+All accesses to main memory go through the map circuit as mentioned
+previously. This function is described here.
+
+The map circuit performs address translation plus access privilege
+checking for each page in memory.
+
+The map registers are addressable only by the Job Processor in system
+space 16 bits at a time.
+
+The addresss are 900000 thru 903FFF (9 0 00up pppp pppp ppw0).
+
+The addressing for the map is given below:
+
+Address decode:
+
+u           = 1 if page is in system space
+ppppppppppp = page number
+w           = Word select
+
+Data decode:
+
+Word 1 = rwxn nnnn nnnn nnnn
+         r   = 0, read enable
+          w  = 0, write enable
+           x = 0, execute enable
+            n nnnn nnnn nnnn = physical page number
+
+Word 0 = iiii iiii xxxx xxrd
+         iiii iiii = user id
+                          r  = 1, set when page is referenced
+                           d = 1, set when page is altered
 */
 
 typedef struct {

--- a/mapper.c
+++ b/mapper.c
@@ -108,7 +108,7 @@ static int access_allowed_page(mapper_t *m, unsigned int page, int access_flags)
 		if (fault&(ACCESS_W<<16)) MAPPER_LOG_DEBUG("write violation ");
 		if (fault&(ACCESS_R<<16)) MAPPER_LOG_DEBUG("read violation ");
 		if (fault&(ACCESS_X<<16)) MAPPER_LOG_DEBUG("execute violation ");
-		if (fault&0xff00) MAPPER_LOG_DEBUG("proc uid %d page uid %d ", m->cur_id, uid);
+		MAPPER_LOG_DEBUG("proc uid %d %s page uid %d ", uid, (m->cur_id==uid?"=":"!="), m->cur_id);
 		if (access_flags&ACCESS_SYSTEM) MAPPER_LOG_DEBUG("system ");
 		MAPPER_LOG_DEBUG(")\n");
 	}

--- a/mapper.c
+++ b/mapper.c
@@ -104,12 +104,23 @@ static int access_allowed_page(mapper_t *m, unsigned int page, int access_flags)
 		if (uid != m->cur_id) fault|=(uid<<8|0xff);
 	}
 	if (fault) {
-		MAPPER_LOG_DEBUG("Mapper: Access fault: page %04x ent w0=%04x, w1=%04x req %x, fault %x (", page, m->desc[page].w0, m->desc[page].w1, access_flags, fault);
+		MAPPER_LOG_DEBUG("Mapper: Access fault: page %04x ent "
+				 "w0=%04x, w1=%04x (page_perm=%c%c%c), "
+				 "req %x (req_perm=%c%c%c), %s, fault %x (",
+				page, m->desc[page].w0, m->desc[page].w1,
+				((m->desc[page].w1&ACCESS_R)?'-':'R'), // page flags: 1 if *blocked*
+				((m->desc[page].w1&ACCESS_W)?'-':'W'),
+				((m->desc[page].w1&ACCESS_X)?'-':'X'),
+				access_flags,
+				((access_flags&ACCESS_R)?'R':'-'),     // req flags: 1 if requested
+				((access_flags&ACCESS_W)?'W':'.'),
+				((access_flags&ACCESS_X)?'X':'-'),
+				((access_flags&ACCESS_SYSTEM)?"system":"user"),
+				fault);
 		if (fault&(ACCESS_W<<16)) MAPPER_LOG_DEBUG("write violation ");
 		if (fault&(ACCESS_R<<16)) MAPPER_LOG_DEBUG("read violation ");
 		if (fault&(ACCESS_X<<16)) MAPPER_LOG_DEBUG("execute violation ");
 		MAPPER_LOG_DEBUG("proc uid %d %s page uid %d ", uid, (m->cur_id==uid?"=":"!="), m->cur_id);
-		if (access_flags&ACCESS_SYSTEM) MAPPER_LOG_DEBUG("system ");
 		MAPPER_LOG_DEBUG(")\n");
 	}
 	return fault;

--- a/mapper.c
+++ b/mapper.c
@@ -104,7 +104,7 @@ static int access_allowed_page(mapper_t *m, unsigned int page, int access_flags)
 		if (uid != m->cur_id) fault|=(uid<<8|0xff);
 	}
 	if (fault) {
-		MAPPER_LOG_DEBUG("Mapper: Access fault: page ent %x%x req %x, fault %x (", m->desc[page].w0, m->desc[page].w1, access_flags, fault);
+		MAPPER_LOG_DEBUG("Mapper: Access fault: page ent w0=%04x, w1=%04x req %x, fault %x (", m->desc[page].w0, m->desc[page].w1, access_flags, fault);
 		if (fault&(ACCESS_W<<16)) MAPPER_LOG_DEBUG("write violation ");
 		if (fault&(ACCESS_R<<16)) MAPPER_LOG_DEBUG("read violation ");
 		if (fault&(ACCESS_X<<16)) MAPPER_LOG_DEBUG("execute violation ");
@@ -152,7 +152,7 @@ void mapper_write16(void *obj, unsigned int a, unsigned int val) {
 	} else {
 		m->desc[a/2].w0=val;
 	}
-	if (a/2==2048) MAPPER_LOG_DEBUG("write page %d, w%d. w0=%x, w1=%x\n", a/2, a&1, m->desc[a/2].w0, m->desc[a/2].w1);
+	if (a/2==2048) MAPPER_LOG_DEBUG("write page %d, w%d. w0=%04x, w1=%04x\n", a/2, a&1, m->desc[a/2].w0, m->desc[a/2].w1);
 }
 
 void mapper_write32(void *obj, unsigned int a, unsigned int val) {
@@ -164,7 +164,7 @@ void mapper_write32(void *obj, unsigned int a, unsigned int val) {
 unsigned int mapper_read16(void *obj, unsigned int a) {
 	mapper_t *m=(mapper_t*)obj;
 	a=a/2; //word addr
-	if (a/2==2048) MAPPER_LOG_DEBUG("read page %d, w%d. w0=%x, w1=%x\n", a/2, a&1, m->desc[a/2].w0, m->desc[a/2].w1);
+	if (a/2==2048) MAPPER_LOG_DEBUG("read page %d, w%d. w0=%04x, w1=%04x\n", a/2, a&1, m->desc[a/2].w0, m->desc[a/2].w1);
 	if (a&1) {
 		return m->desc[a/2].w1;
 	} else {

--- a/mapper.c
+++ b/mapper.c
@@ -104,11 +104,12 @@ static int access_allowed_page(mapper_t *m, unsigned int page, int access_flags)
 		if (uid != m->cur_id) fault|=(uid<<8|0xff);
 	}
 	if (fault) {
-		MAPPER_LOG_DEBUG("Mapper: Access fault: page ent w0=%04x, w1=%04x req %x, fault %x (", m->desc[page].w0, m->desc[page].w1, access_flags, fault);
+		MAPPER_LOG_DEBUG("Mapper: Access fault: page %04x ent w0=%04x, w1=%04x req %x, fault %x (", page, m->desc[page].w0, m->desc[page].w1, access_flags, fault);
 		if (fault&(ACCESS_W<<16)) MAPPER_LOG_DEBUG("write violation ");
 		if (fault&(ACCESS_R<<16)) MAPPER_LOG_DEBUG("read violation ");
 		if (fault&(ACCESS_X<<16)) MAPPER_LOG_DEBUG("execute violation ");
 		if (fault&0xff00) MAPPER_LOG_DEBUG("proc uid %d page uid %d ", m->cur_id, uid);
+		if (access_flags&ACCESS_SYSTEM) MAPPER_LOG_DEBUG("system ");
 		MAPPER_LOG_DEBUG(")\n");
 	}
 	return fault;

--- a/mapper.h
+++ b/mapper.h
@@ -23,9 +23,9 @@ void mapper_set_mapid(mapper_t *m, uint8_t id);
 
 //note RWX flags match page tables
 #define ACCESS_SYSTEM 0x1
-#define ACCESS_R 0x80000000
-#define ACCESS_W 0x40000000
-#define ACCESS_X 0x20000000
+#define ACCESS_R 0x8000
+#define ACCESS_W 0x4000
+#define ACCESS_X 0x2000
 
 //Returns one of ACCESS_ERROR_x
 int mapper_access_allowed(mapper_t *m, unsigned int a, int access_flags);


### PR DESCRIPTION
For readability of the mapper code (a) bring in the mapper documentation into comments, and (b) avoid combining w0 and w1 together (except in print out, which is now big endian), as suggested by paulb on Discord.