### PR TITLE
Fix Multibus diagnostic error with minor change in Musashi

### DIFF
--- a/Musashi/m68kcpu.h
+++ b/Musashi/m68kcpu.h
@@ -1996,6 +1996,7 @@ static inline void m68ki_exception_bus_error(void)
 	m68ki_jump_vector(EXCEPTION_BUS_ERROR);
 
 	CPU_RUN_MODE = RUN_MODE_BERR_AERR_RESET;
+	FLAG_INT_MASK = 0x0700;
 
 	longjmp(m68ki_bus_error_jmp_buf, 1);
 }

--- a/Musashi/m68kcpu.h
+++ b/Musashi/m68kcpu.h
@@ -1996,7 +1996,7 @@ static inline void m68ki_exception_bus_error(void)
 	m68ki_jump_vector(EXCEPTION_BUS_ERROR);
 
 	CPU_RUN_MODE = RUN_MODE_BERR_AERR_RESET;
-	FLAG_INT_MASK = 0x0700;
+	
 
 	longjmp(m68ki_bus_error_jmp_buf, 1);
 }

--- a/csr.c
+++ b/csr.c
@@ -146,7 +146,8 @@ void csr_set_access_error(csr_t *csr, int cpu, int type, int addr, int is_write)
 	if (type&ACCESS_ERROR_MBTO) {
 		v|=ERR_MBTO;
 		if (emu_get_mb_diag()) {
-			emu_raise_int(INT_VECT_MB_IF_ERR, INT_LEVEL_MB_IF_ERR, 1);
+			if (is_write)
+				emu_raise_int(INT_VECT_MB_IF_ERR, INT_LEVEL_MB_IF_ERR, 1);
 			csr->reg[CSR_I_MBERR/2]=(addr>>11)&0xfe;
 			if (!is_write) csr->reg[CSR_I_MBERR/2]|=0x1;
 		}

--- a/mbus.c
+++ b/mbus.c
@@ -63,7 +63,7 @@ unsigned int mbus_read8(void *obj, unsigned int a) {
 	MBUS_LOG_DEBUG("MBUS: rb %x->%x\n", a, a+0x780000);
 	if (!emu_get_mb_diag()) return 0;
 	//Mbus in diag modes errors with a MBTO.
-	emu_mbus_error(a|EMU_MBUS_BUSERROR);
+	emu_mbus_error(a|EMU_MBUS_ERROR_READ|EMU_MBUS_BUSERROR);
 	return 0;
 }
 
@@ -71,7 +71,7 @@ unsigned int mbus_read16(void *obj, unsigned int a) {
 	MBUS_LOG_DEBUG("MBUS: rw %x->%x\n", a, a+0x780000);
 	if (!emu_get_mb_diag()) return 0;
 	//Mbus in diag modes errors with a MBTO.
-	emu_mbus_error(a|EMU_MBUS_BUSERROR);
+	emu_mbus_error(a|EMU_MBUS_ERROR_READ|EMU_MBUS_BUSERROR);
 	return 0;
 }
 


### PR DESCRIPTION
Fixes the Multibus diag error by preventing Musashi from interrupting the bus error handler. I set the interrupt mask to 7 on a bus error, can't figure out if that is what the actual CPU does though, manual is not clear (or I am blind, take your pick).